### PR TITLE
feat: add sonnet 4.5 support

### DIFF
--- a/capsule-agents-backend/src/lib/model-registry.ts
+++ b/capsule-agents-backend/src/lib/model-registry.ts
@@ -39,6 +39,13 @@ export const OPENAI_MODELS: ModelEntry[] = [
 // Anthropic Models
 export const ANTHROPIC_MODELS: ModelEntry[] = [
   {
+    id: "anthropic/claude-sonnet-4.5-latest",
+    name: "Claude 4.5 Sonnet",
+    description:
+      "Latest Claude Sonnet model with enhanced reasoning depth and 1M context window",
+    pricing: { input: 0.004, output: 0.02 },
+  },
+  {
     id: "anthropic/claude-sonnet-4-20250514",
     name: "Claude 4 Sonnet",
     description:
@@ -131,6 +138,7 @@ export function selectDefaultModel(
   const priorityOrder = [
     "openai/gpt-5-mini",
     "google/gemini-2.5-flash",
+    "anthropic/claude-sonnet-4.5-latest",
     "anthropic/claude-sonnet-4-latest",
     "openai/gpt-5",
     "google/gemini-2.0-flash",


### PR DESCRIPTION
## Summary
- add the Claude 4.5 Sonnet model entry with pricing and description to the Anthropic provider list
- update the default model priority ordering to prefer Claude 4.5 Sonnet when available

## Testing
- ⚠️ `deno fmt src/lib/model-registry.ts` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e304ec7fcc832d81e8cb091a722954